### PR TITLE
Update orders.set.limit method name

### DIFF
--- a/orders.go
+++ b/orders.go
@@ -154,7 +154,7 @@ func (client *NicehashClient) OrderSetLimit(algo AlgoType, location Location, or
 			Success string `json:"success"`
 		} `json:"result"`
 	}{}
-	params := &Params{Method: "orders.set.price.limit", Algo: algo, Location: location, Order: order, Limit: limit, ApiId: client.apiid, ApiKey: client.apikey}
+	params := &Params{Method: "orders.set.limit", Algo: algo, Location: location, Order: order, Limit: limit, ApiId: client.apiid, ApiKey: client.apikey}
 	_, err := client.sling.New().Get("").QueryStruct(params).ReceiveSuccess(&stats)
 	if err != nil {
 		return stats.Result.Success, err


### PR DESCRIPTION
The name of the method in the nicehash has been changed from orders.set.price.limit to orders.set.limit